### PR TITLE
Implement optional overclock for the 68000

### DIFF
--- a/MegaDrivePlusPlus.ino
+++ b/MegaDrivePlusPlus.ino
@@ -68,7 +68,7 @@
  *   connected to the onboard Serial <-> USB converter on Arduino boards.
  */
 
-//#define OVERCLOCK
+#define OVERCLOCK
 
 #define RESET_IN_PIN A1
 #define RESET_OUT_PIN A0
@@ -236,10 +236,10 @@ const int CLK = 13;
 const int DATA = 11;
 
 const unsigned long freq_step =   500000;
-const unsigned long min_freq  =  8000000;               // Set min frequency. 8Mhz
+const unsigned long min_freq  =  7000000;               // Set min frequency. 8Mhz
 const unsigned long max_freq  = 12500000;               // Set max frequency. 12.5Mhz
 
-unsigned long freq = 8000000;               // Set initial frequency.
+unsigned long freq = 9000000;               // Set initial frequency.
 
 #endif
 
@@ -920,18 +920,15 @@ inline void handle_pad () {
 #endif
 #ifdef FREQ_DOWN_COMBO
     } else if ((pad_status & FREQ_UP_COMBO) == FREQ_UP_COMBO) {
-
       fastDigitalWrite (DEBUG_LED, LOW);
       delay (100);
       fastDigitalWrite (DEBUG_LED, HIGH);
-      delay (100);
       debugln (F("rise the cpu clock 0.5 Mhz"));
       freq -= freq_step;
-      if (freq <= min_freq) {
-         fastDigitalWrite (DEBUG_LED, LOW);
+      if (freq < min_freq) {
+        fastDigitalWrite (DEBUG_LED, LOW);
         delay (100);
         fastDigitalWrite (DEBUG_LED, HIGH);
-        delay (100);
         freq = min_freq;
       }
       AD9833setFrequency(freq, SQUARE);
@@ -939,18 +936,15 @@ inline void handle_pad () {
 #endif
 #ifdef FREQ_UP_COMBO
     } else if ((pad_status & FREQ_DOWN_COMBO) == FREQ_DOWN_COMBO) {
-
       fastDigitalWrite (DEBUG_LED, LOW);
       delay (100);
       fastDigitalWrite (DEBUG_LED, HIGH);
-      delay (100);
       debugln (F("low the cpu clock 0.5 Mhz"));
       freq += freq_step;
-      if (freq >= max_freq) {
+      if (freq > max_freq) {
         fastDigitalWrite (DEBUG_LED, LOW);
         delay (100);
         fastDigitalWrite (DEBUG_LED, HIGH);
-        delay (100);
         freq = max_freq;
       }
       AD9833setFrequency(freq, SQUARE);

--- a/MegaDrivePlusPlus.ino
+++ b/MegaDrivePlusPlus.ino
@@ -123,6 +123,13 @@ enum __attribute__ ((__packed__)) PadButton {
  */
 #define RESET_COMBO (MD_BTN_A | MD_BTN_C)
 
+#ifdef OVERCLOCK
+
+#define FREQ_DOWN_COMBO MD_BTN_A
+#define FREQ_UP_COMBO MD_BTN_C
+
+#endif
+
 // Region/video mode combos
 #define EUR_COMBO MD_BTN_DOWN
 #define USA_COMBO MD_BTN_RIGHT

--- a/MegaDrivePlusPlus.ino
+++ b/MegaDrivePlusPlus.ino
@@ -229,7 +229,7 @@ const int TRIANGLE = 0x2002;
 // internal reference
 // AD9833 25Mhz == 25000000.0
 // AD9834 75Mhz == 75000000.0
-const float refFreq = 75000000.0;
+const float refFreq = 25000000.0;
 
 const int FSYNC = 10;                        // Standard SPI pins for the AD9833/4 waveform generators.
 const int CLK = 13;
@@ -530,9 +530,9 @@ void reset_console () {
 
 #ifdef OVERCLOCK
 
-void reset();
-void setFrequency(long frequency, int Waveform);
-void WriteRegister(int dat);
+void AD9833reset();
+void AD9833setFrequency(long frequency, int Waveform);
+void AD9833writeRegister(int dat);
 
 #endif
 
@@ -547,7 +547,7 @@ void setup () {
   delay(50);
   AD9833reset();
   delay(50);
-  AD9833setFrequency(freq, TRIANGLE);
+  AD9833setFrequency(freq, SQUARE);
   fastPinMode(DEBUG_LED, OUTPUT);
   fastDigitalWrite(DEBUG_LED, HIGH);
 #endif
@@ -966,14 +966,14 @@ inline void handle_pad () {
 #ifdef OVERCLOCK
 
 // AD9833 documentation advises a 'Reset' on first applying power.
-void reset() {
-  WriteRegister(0x100);   // Write '1' to AD9833 Control register bit D8.
+void AD9833reset() {
+  AD9833writeRegister(0x100);   // Write '1' to AD9833 Control register bit D8.
   delay(10);
 }
 
 
 // Set the frequency and waveform registers in the AD9833/4.
-void setFrequency(long frequency, int Waveform) {
+void AD9833setFrequency(long frequency, int Waveform) {
 
   long FreqWord = (frequency * pow(2, 28)) / refFreq;
 
@@ -984,14 +984,14 @@ void setFrequency(long frequency, int Waveform) {
   LSB |= 0x4000;
   MSB |= 0x4000;
 
-  WriteRegister(0x2100);
-  WriteRegister(LSB);                  // Write lower 16 bits to AD9833 registers
-  WriteRegister(MSB);                  // Write upper 16 bits to AD9833 registers.
-  WriteRegister(0xC000);               // Phase register
-  WriteRegister(Waveform);             // Exit & Reset to SINE, SQUARE or TRIANGLE
+  AD9833writeRegister(0x2100);
+  AD9833writeRegister(LSB);                  // Write lower 16 bits to AD9833 registers
+  AD9833writeRegister(MSB);                  // Write upper 16 bits to AD9833 registers.
+  AD9833writeRegister(0xC000);               // Phase register
+  AD9833writeRegister(Waveform);             // Exit & Reset to SINE, SQUARE or TRIANGLE
 }
 
-void writeRegister(int dat) {
+void AD9833writeRegister(int dat) {
 
   // Display and AD9833 use different SPI MODES so it has to be set for the AD9833 here.
   SPI.setDataMode(SPI_MODE2);


### PR DESCRIPTION
Hello,

This modifications allows to overclock the MEGADRIVE 68000


COMBO-KEYS

START + B + A rises 0.5Mhz step
START + B + C downs 0.5Mhz step

From 8Mhz to 12.5Mhz

It works pretty well in a PAL MODEL 1600-18
not so well in PAL MODEL 1601-18 (Very unstable)

Hardware:


requires one external SPI function genrator

this one
AD9833 with 25Mhz reference frequency
or this one

AD9834 with 75Mhz reference frequency
also others could work

(changing the reference frequency in code is required)

GAMES

Games now run at the same speed but no more slowdown with many sprites on screen

games tested:

Street of rage 1, 2 & 3
Out Run
Super Hang ON
Sonic 1, 2 & 3
Aladin
Comix Zone
Dynamite Headdy
Gould'n Ghosts
Gunstar Heroes
Marble Land
Rocket Kinight Adventures
Megaman
Sparkster
Subterranea
Street Fighter 2 Turbo
Toe Jam & Earl
Thunder Force 3
Ristar
Contra Hard Corps
Castlevania Blood Line
Castle of Ilusion
Bubsy


Thanks